### PR TITLE
Add getIdentities function

### DIFF
--- a/misc.js
+++ b/misc.js
@@ -150,7 +150,7 @@ function fillIdentities(aSkipNntp) {
   Log.debug("Filling identities with skipnntp = ", aSkipNntp);
 
   gIdentities = {};
-  for each (let currentIdentity in gIdentities) {
+  for each (let currentIdentity in getIdentities(aSkipNntp)) {
     gIdentities[currentIdentity.identity.email] = currentIdentity.identity;
     if (currentIdentity.isDefault) {
       gIdentities["default"] = currentIdentity.identity;


### PR DESCRIPTION
I implemented your suggestions from https://github.com/protz/GMail-Conversation-View/pull/866.

Should getDefaultIdentity() rather return only the nsIMsgIdentity-object instead of the struct? isDefault would always be true!
