### PR TITLE
Change from parseHeadersWithArray to parseEncodedHeader to fix post 70 compatibility.

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -20,6 +20,7 @@ var EXPORTED_SYMBOLS = [
   "determineComposeHtml",
   "composeMessageTo",
   "getSignatureContentsForAccount",
+  "parse",
 ];
 
 const { XPCOMUtils } = ChromeUtils.import(
@@ -325,20 +326,16 @@ function plainTextToHtml(txt) {
   return newLines.join("\n");
 }
 
-function parse(aMimeLine) {
-  if (!aMimeLine) {
+function parse(mimeLine) {
+  if (!mimeLine) {
     return [[], []];
   }
-  let emails = {};
-  let fullNames = {};
-  let names = {};
-  MailServices.headerParser.parseHeadersWithArray(
-    aMimeLine,
-    emails,
-    names,
-    fullNames
-  );
-  return [names.value, emails.value];
+  // The null here copes with pre-Thunderbird 71 compatibility.
+  let addresses = MailServices.headerParser.parseEncodedHeader(mimeLine, null);
+  if (addresses[0]) {
+    return [addresses[0].name, addresses[0].email];
+  }
+  return [[], []];
 }
 
 /**

--- a/misc.js
+++ b/misc.js
@@ -275,34 +275,30 @@ function escapeHtml(s) {
 
 /**
  * Wraps the low-level header parser stuff.
- * @param {String} aMimeLine a line that looks like "John &lt;john@cheese.com&gt;, Jane &lt;jane@wine.com&gt;"
- * @param {Boolean} aDontFix (optional) Default to false. Shall we return an
- *  empty array in case aMimeLine is empty?
- * @return {Array} a list of { email, name } objects
+ * @param {String} mimeLine
+ *   A line that looks like "John &lt;john@cheese.com&gt;, Jane &lt;jane@wine.com&gt;"
+ * @param {Boolean} [dontFix]
+ *   Defaults to false. Shall we return an empty array in case aMimeLine is empty?
+ * @return {Array}
+ *   A list of { email, name } objects
  */
-function parseMimeLine(aMimeLine, aDontFix) {
-  if (aMimeLine == null) {
+function parseMimeLine(mimeLine, dontFix) {
+  if (mimeLine == null) {
     Log.debug("Empty aMimeLine?!!");
     return [];
   }
-  let emails = {};
-  let fullNames = {};
-  let names = {};
-  let numAddresses = MailServices.headerParser.parseHeadersWithArray(
-    aMimeLine,
-    emails,
-    names,
-    fullNames
-  );
-  if (numAddresses) {
-    return [...range(0, numAddresses)].map(i => {
+  // The null here copes with pre-Thunderbird 71 compatibility.
+  let addresses = MailServices.headerParser.parseEncodedHeader(mimeLine, null);
+  if (addresses.length) {
+    return addresses.map(addr => {
       return {
-        email: emails.value[i],
-        name: names.value[i],
-        fullName: fullNames.value[i],
+        email: addr.email,
+        name: addr.name,
+        fullName: addr.toString(),
       };
     });
-  } else if (aDontFix) {
+  }
+  if (dontFix) {
     return [];
   }
   return [{ email: "", name: "-", fullName: "-" }];


### PR DESCRIPTION
`parseEncodedHeader` was added several years back, but `parseHeadersWithArray` has actually been removed now (https://bugzilla.mozilla.org/show_bug.cgi?id=1585512).