### PR TITLE
Lazy load modules as much as possible, and lazy initialise logging.

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -27,9 +27,13 @@ const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
 
+const logJSURL = new URL("../log.js", this.__URI__);
+
 XPCOMUtils.defineLazyModuleGetters(this, {
+  logRoot: logJSURL,
   MailServices: "resource:///modules/MailServices.jsm",
   NetUtil: "resource://gre/modules/NetUtil.jsm",
+  setupLogging: logJSURL,
   Services: "resource://gre/modules/Services.jsm",
 });
 
@@ -48,7 +52,6 @@ const { msgHdrGetUri, getMail3Pane, msgHdrGetHeaders } = importRelative(
   this,
   "msgHdrUtils.js"
 );
-const { logRoot, setupLogging } = importRelative(this, "../log.js");
 
 let Log = setupLogging(logRoot + ".Stdlib");
 

--- a/misc.js
+++ b/misc.js
@@ -40,10 +40,14 @@ const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
 
+const logJSURL = new URL("../log.js", this.__URI__);
+
 XPCOMUtils.defineLazyModuleGetters(this, {
   AppConstants: "resource://gre/modules/AppConstants.jsm",
   fixIterator: "resource:///modules/iteratorUtils.jsm",
+  logRoot: logJSURL,
   MailServices: "resource:///modules/MailServices.jsm",
+  setupLogging: logJSURL,
   Services: "resource://gre/modules/Services.jsm",
 });
 
@@ -57,12 +61,9 @@ if (!Services.intl) {
   );
 }
 
-const { logRoot, setupLogging } = ChromeUtils.import(
-  new URL("../log.js", this.__URI__),
-  null
-);
-
-let Log = setupLogging(logRoot + ".Stdlib");
+XPCOMUtils.defineLazyGetter(this, "Log", () => {
+  return setupLogging(logRoot + ".Stdlib");
+});
 
 let isOSX = AppConstants.platform === "macosx";
 let isWindows = AppConstants.platform === "win";

--- a/msgHdrUtils.js
+++ b/msgHdrUtils.js
@@ -51,17 +51,15 @@ const { XPCOMUtils } = ChromeUtils.import(
 );
 
 XPCOMUtils.defineLazyModuleGetters(this, {
+  entries: new URL("misc.js", this.__URI__),
   MailServices: "resource:///modules/MailServices.jsm",
   MailUtils: "resource:///modules/MailUtils.jsm",
   MessageArchiver: "resource:///modules/MessageArchiver.jsm",
+  MimeMessage: "resource:///modules/gloda/mimemsg.js",
+  MsgHdrToMimeMessage: "resource:///modules/gloda/mimemsg.js",
   Services: "resource://gre/modules/Services.jsm",
   toXPCOMArray: "resource:///modules/iteratorUtils.jsm",
 });
-const { MimeMessage, MsgHdrToMimeMessage } = ChromeUtils.import(
-  "resource:///modules/gloda/mimemsg.js"
-);
-
-const { entries } = ChromeUtils.import(new URL("misc.js", this.__URI__));
 
 // Adding a messenger lazy getter to the MailServices even though it's not a service
 XPCOMUtils.defineLazyGetter(MailServices, "messenger", function() {


### PR DESCRIPTION
This helps to avoid unnecessary loading on startup, and ensures that logging preferences can be initialised properly.